### PR TITLE
Improve setup instructions for each demo, and fix OpenCV req script

### DIFF
--- a/gstreamer/README.md
+++ b/gstreamer/README.md
@@ -1,7 +1,7 @@
-# GStreamer examples for inferencing on Coral
+# GStreamer camera examples with Coral
 
 This folder contains example code using [GStreamer](https://github.com/GStreamer/gstreamer) to
-obtain camera images and then perform image classification or object detection on the Edge TPU.
+obtain camera images and perform image classification and object detection on the Edge TPU.
 
 This code works on Linux using a webcam, Raspberry Pi with the Pi Camera, and on the Coral Dev
 Board using the Coral Camera or a webcam. For the first two, you also need a Coral
@@ -59,8 +59,8 @@ You can change the model and the labels file using flags ```--model``` and ```--
 python3 detect.py
 ```
 
-By default, this uses the ```mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite``` model.
+Likewise, you can change the model and the labels file using ```--model``` and ```--labels```.
 
-You can change the model and the labels file using flags ```--model``` and ```--labels```.
-
+By default, both examples use the attached Coral Camera. If you want to use a USB camera,
+edit the ```gstreamer.py``` file and change ```device=/dev/video0``` to ```device=/dev/video1```.
 

--- a/gstreamer/README.md
+++ b/gstreamer/README.md
@@ -32,13 +32,9 @@ USB/PCIe/M.2 Accelerator.
 4.  Install the GStreamer libraries (if you're using the Coral Dev Board, you can skip this):
 
     ```
-    bash gstreamer/install_requirements.sh
-    ```
-
-5.  Navigate to this code:
-
-    ```
     cd gstreamer
+
+    bash install_requirements.sh
     ```
 
 

--- a/gstreamer/detect.py
+++ b/gstreamer/detect.py
@@ -12,16 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""A demo which runs object detection on camera frames.
+"""A demo which runs object detection on camera frames using GStreamer.
 
-export TEST_DATA=/usr/lib/python3/dist-packages/edgetpu/test_data
+TEST_DATA=../all_models
 
 Run face detection model:
-python3 -m edgetpuvision.detect \
+python3 detect.py \
   --model ${TEST_DATA}/mobilenet_ssd_v2_face_quant_postprocess_edgetpu.tflite
 
 Run coco model:
-python3 -m edgetpuvision.detect \
+python3 detect.py \
   --model ${TEST_DATA}/mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite \
   --labels ${TEST_DATA}/coco_labels.txt
 """

--- a/gstreamer/gstreamer.py
+++ b/gstreamer/gstreamer.py
@@ -61,7 +61,10 @@ def detectCoralDevBoard():
 def run_pipeline(user_function,
                  src_size=(640,480),
                  appsink_size=(320, 180)):
+    # For default camera (Coral Camera w/ Dev Board):
     PIPELINE = 'v4l2src device=/dev/video0 ! {src_caps} ! {leaky_q} '
+    # For alternative camera (USB camera w/ Dev Board):
+    #PIPELINE = 'v4l2src device=/dev/video1 ! {src_caps} ! {leaky_q} '
     if detectCoralDevBoard():
         SRC_CAPS = 'video/x-raw,format=YUY2,width={width},height={height},framerate=30/1'
         PIPELINE += """ ! glupload ! tee name=t

--- a/opencv/README.md
+++ b/opencv/README.md
@@ -1,7 +1,7 @@
-# GStreamer examples for inferencing on Coral
+# OpenCV examples for inferencing on Coral
 
-This folder contains example code using [GStreamer](https://github.com/GStreamer/gstreamer) to
-obtain camera images and then perform image classification or object detection on the Edge TPU.
+This folder contains example code using [OpenVC](https://github.com/opencv/opencv) to obtain
+camera images and then perform object detection on the Edge TPU.
 
 This code works on Linux using a webcam, Raspberry Pi with the Pi Camera, and on the Coral Dev
 Board using the Coral Camera or a webcam. For the first two, you also need a Coral
@@ -29,28 +29,17 @@ USB/PCIe/M.2 Accelerator.
     sh download_models.sh
     ```
 
-4.  Install the GStreamer libraries (if you're using the Coral Dev Board, you can skip this):
+4.  Install the OpenCV libraries:
 
     ```
-    bash gstreamer/install_requirements.sh
+    bash opencv/install_requirements.sh
     ```
 
 5.  Navigate to this code:
 
     ```
-    cd gstreamer
+    cd opencv
     ```
-
-
-## Run the classification demo
-
-```
-python3 classify.py
-```
-
-By default, this uses the ```mobilenet_v2_1.0_224_quant_edgetpu.tflite``` model.
-
-You can change the model and the labels file using flags ```--model``` and ```--labels```.
 
 
 ## Run the detection demo (SSD models)
@@ -61,6 +50,7 @@ python3 detect.py
 
 By default, this uses the ```mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite``` model.
 
-You can change the model and the labels file using flags ```--model``` and ```--labels```.
+You can change the model and the labels file using flags ```--model```
+and ```--labels```.
 
 

--- a/opencv/README.md
+++ b/opencv/README.md
@@ -1,7 +1,7 @@
-# OpenCV examples for inferencing on Coral
+# OpenCV camera examples with Coral
 
 This folder contains example code using [OpenVC](https://github.com/opencv/opencv) to obtain
-camera images and then perform object detection on the Edge TPU.
+camera images and perform object detection on the Edge TPU.
 
 This code works on Linux using a webcam, Raspberry Pi with the Pi Camera, and on the Coral Dev
 Board using the Coral Camera or a webcam. For the first two, you also need a Coral
@@ -50,7 +50,4 @@ python3 detect.py
 
 By default, this uses the ```mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite``` model.
 
-You can change the model and the labels file using flags ```--model```
-and ```--labels```.
-
-
+You can change the model and the labels file using flags ```--model``` and ```--labels```.

--- a/opencv/README.md
+++ b/opencv/README.md
@@ -32,13 +32,9 @@ USB/PCIe/M.2 Accelerator.
 4.  Install the OpenCV libraries:
 
     ```
-    bash opencv/install_requirements.sh
-    ```
-
-5.  Navigate to this code:
-
-    ```
     cd opencv
+
+    bash install_requirements.sh
     ```
 
 

--- a/opencv/detect.py
+++ b/opencv/detect.py
@@ -12,20 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""A demo which runs object detection on camera frames.
+"""A demo that runs object detection on camera frames using OpenCV.
 
-export TEST_DATA=/usr/lib/python3/dist-packages/edgetpu/test_data
+TEST_DATA=../all_models
 
 Run face detection model:
-python3 -m edgetpuvision.detect \
+python3 detect.py \
   --model ${TEST_DATA}/mobilenet_ssd_v2_face_quant_postprocess_edgetpu.tflite
 
 Run coco model:
-python3 -m edgetpuvision.detect \
+python3 detect.py \
   --model ${TEST_DATA}/mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite \
   --labels ${TEST_DATA}/coco_labels.txt
-
-Press Q key to exit.
 
 """
 import cv2
@@ -89,12 +87,12 @@ def append_objs_to_img(cv2_im, objs, labels):
     height, width, channels = cv2_im.shape
     for obj in objs:
         x0, y0, x1, y1 = obj.bounding_box.flatten().tolist()
-        x0, y0, x1, y1 = int(x0*width), int(y0*height), int(x1*width), int(y1*height)  
+        x0, y0, x1, y1 = int(x0*width), int(y0*height), int(x1*width), int(y1*height)
         percent = int(100 * obj.score)
         label = '%d%% %s' % (percent, labels[obj.label_id])
 
         cv2_im = cv2.rectangle(cv2_im, (x0, y0), (x1, y1), (0, 255, 0), 2)
-        cv2_im = cv2.putText(cv2_im, label, (x0, y0+30), 
+        cv2_im = cv2.putText(cv2_im, label, (x0, y0+30),
                              cv2.FONT_HERSHEY_SIMPLEX, 1.0, (255, 0, 0), 2)
     return cv2_im
 

--- a/opencv/install_requirements.sh
+++ b/opencv/install_requirements.sh
@@ -15,7 +15,12 @@
 # limitations under the License.
 
 if grep -s -q "MX8MQ" /sys/firmware/devicetree/base/model; then
-  echo "OpenCV is not yet suppported for DevBoard"
-else
-  sudo apt install python3-opencv
+  MENDEL_VER="$(cat /etc/mendel_version)"
+  if [[ "$MENDEL_VER" == "1.0" || "$MENDEL_VER" == "2.0" || "$MENDEL_VER" == "3.0" ]]; then
+    echo "Your version of Mendel is not compatible with OpenCV."
+    echo "You must upgrade to Mendel 4.0 or higher."
+    exit 1
+  fi
 fi
+
+sudo apt install python3-opencv

--- a/pygame/README.md
+++ b/pygame/README.md
@@ -1,25 +1,62 @@
-This folder contains some simple camera classification and detection examples using pygame
+# P examples for inferencing on Coral
 
-If you dont have pygame installed you can install it by:
-```
-pip3 install pygame
-```
+This folder contains example code using [pygame](https://github.com/pygame/pygame) to obtain
+camera images and then perform image classification or object detection on the Edge TPU.
 
-To run the demo execture the following command, which will use the default 
-model ```mobilenet_v2_1.0_224_quant_edgetpu.tflite``` 
+## Set up your device
 
-You run the classifier with:
+1.  First, be sure you have completed the [setup instructions for your Coral
+    device](https://coral.ai/docs/setup/).
+
+2.  Clone this Git repo onto your computer or Dev Board:
+
+    ```
+    mkdir google-coral && cd google-coral
+
+    git clone https://github.com/google-coral/examples-camera --depth 1
+    ```
+
+3.  Download the models:
+
+    ```
+    cd examples-camera
+
+    sh download_models.sh
+    ```
+
+4.  Install pygame:
+
+    ```
+    bash pygame/install_requirements.sh
+    ```
+
+5.  Navigate to this code:
+
+    ```
+    cd pygame
+    ```
+
+
+
+## Run the classification demo
+
 ```
 python3 classify_capture.py
-``` 
-
-You can change the model and the labels file using flags:
 ```
-python3 classify_capture.py --model ../all_models/inception_v3_299_quant_edgetpu.tflite
-``` 
 
-You run the detector with:
+By default, this uses the ```mobilenet_v2_1.0_224_quant_edgetpu.tflite``` model.
+
+You can change the model and the labels file using flags ```--model``` and ```--labels```.
+
+
+## Run the detection demo (SSD models)
+
 ```
 python3 detect.py
 ```
+
+By default, this uses the ```mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite``` model.
+
+You can change the model and the labels file using flags ```--model``` and ```--labels```.
+
 

--- a/pygame/README.md
+++ b/pygame/README.md
@@ -27,15 +27,10 @@ camera images and then perform image classification or object detection on the E
 4.  Install pygame:
 
     ```
-    bash pygame/install_requirements.sh
-    ```
-
-5.  Navigate to this code:
-
-    ```
     cd pygame
-    ```
 
+    bash install_requirements.sh
+    ```
 
 
 ## Run the classification demo

--- a/pygame/README.md
+++ b/pygame/README.md
@@ -1,4 +1,4 @@
-# P examples for inferencing on Coral
+# Pygame camera examples with Coral
 
 This folder contains example code using [pygame](https://github.com/pygame/pygame) to obtain
 camera images and then perform image classification or object detection on the Edge TPU.

--- a/raspicam/README.md
+++ b/raspicam/README.md
@@ -1,4 +1,4 @@
-# OpenCV camera examples with Coral
+# Raspberry Pi camera examples with Coral
 
 This folder contains example code using [picamera](https://github.com/waveform80/picamera) to obtain
 camera images and perform image classification on the Edge TPU.

--- a/raspicam/README.md
+++ b/raspicam/README.md
@@ -30,7 +30,7 @@ This code works on Raspberry Pi with the Pi Camera and Coral USB Accelerator.
     sh download_models.sh
     ```
 
-5.  Install the picamera library:
+5.  Install picamera:
 
     ```
     cd raspicam

--- a/raspicam/README.md
+++ b/raspicam/README.md
@@ -1,7 +1,7 @@
-# OpenCV examples for inferencing on Coral
+# OpenCV camera examples with Coral
 
 This folder contains example code using [picamera](https://github.com/waveform80/picamera) to obtain
-camera images and then perform image classification on the Edge TPU.
+camera images and perform image classification on the Edge TPU.
 
 This code works on Raspberry Pi with the Pi Camera and Coral USB Accelerator.
 

--- a/raspicam/README.md
+++ b/raspicam/README.md
@@ -1,29 +1,52 @@
-This folder contains some simple camera classification examples specific to Raspberry
-Pi, using the picamera python module to access the camera.
+# OpenCV examples for inferencing on Coral
 
-If you dont have picamera installed you can install it by:
+This folder contains example code using [picamera](https://github.com/waveform80/picamera) to obtain
+camera images and then perform image classification on the Edge TPU.
 
-```
-pip3 install picamera
-```
+This code works on Raspberry Pi with the Pi Camera and Coral USB Accelerator.
 
-Don't forget to enable your camera using raspi-config under "Interfacing Options":
 
-```
-sudo raspi-config 
-```
+## Set up your device
 
-To run the demo execture the following command, which will use the default 
-model ```mobilenet_v2_1.0_224_quant_edgetpu.tflite``` 
+1.  First, be sure you have completed the [setup instructions for the USB
+    Accelerator](https://coral.ai/docs/accelerator/get-started/).
 
+2.  Follow the guide to [connect and configure the Pi Camera](
+    https://www.raspberrypi.org/documentation/configuration/camera.md).
+
+3.  Clone this Git repo onto your Raspberry Pi:
+
+    ```
+    mkdir google-coral && cd google-coral
+
+    git clone https://github.com/google-coral/examples-camera --depth 1
+    ```
+
+4.  Download the models:
+
+    ```
+    cd examples-camera
+
+    sh download_models.sh
+    ```
+
+5.  Install the picamera library:
+
+    ```
+    cd raspicam
+
+    bash install_requirements.sh
+    ```
+
+
+## Run the classification demo
 
 ```
 python3 classify_capture.py
-``` 
-
-You can change the model and the labels file using flags:
-
 ```
-python3 classify_capture.py --model ../all_models/inception_v3_299_quant_edgetpu.tflite
 
-``` 
+By default, this uses the ```mobilenet_v2_1.0_224_quant_edgetpu.tflite``` model.
+
+You can change the model and the labels file using flags ```--model``` and ```--labels```.
+
+


### PR DESCRIPTION
Adds stand-alone setup instructions for each demo, and makes the OpenCV demo compatible with the Dev Board as long as you're on Mendel 4.0+.