### PR TITLE
Converting BasicEngine API to TFLite API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Coral device such as the
     ```
     cd examples-camera
 
-    ./install_requirements.sh
+    sh install_requirements.sh
     ```
 
     These canned models will be downloaded and extracted to a new folder

--- a/README.md
+++ b/README.md
@@ -19,15 +19,17 @@ Coral device such as the
 2.  Clone this Git repo onto your computer:
 
     ```
-    git clone https://github.com/google-coral/examples-camera.git
+    mkdir google-coral && cd google-coral
+
+    git clone https://github.com/google-coral/examples-camera.git --depth 1
     ```
 
-3.  Download a selection of canned models:
+3.  Download the models:
 
     ```
     cd examples-camera
 
-    sh install_requirements.sh
+    sh download_models.sh
     ```
 
     These canned models will be downloaded and extracted to a new folder

--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ Coral device such as the
 ## Installation
 
 1.  First, be sure you have completed the [setup instructions for your Coral
-    device](https://coral.withgoogle.com/docs/accelerator/get-started/).
+    device](https://coral.ai/docs/setup/). If it's been a while, repeat to be sure
+    you have the latest software.
 
     Importantly, you should have the latest TensorFlow Lite runtime installed
     (as per the [Python quickstart](
-    https://www.tensorflow.org/lite/guide/python)
+    https://www.tensorflow.org/lite/guide/python)).
 
 2.  Clone this Git repo onto your computer:
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,36 @@
 # Edge TPU simple camera examples
 
 This repo contains a collection of examples that use camera streams
-together with the Edge TPU Python API.
+together with the [TensorFlow Lite API](https://tensorflow.org/lite) with a
+Coral device such as the
+[USB Accelerator](https://coral.withgoogle.com/products/accelerator) or
+[Dev Board](https://coral.withgoogle.com/products/dev-board).
 
 ## Installation
 
-Before you start using the examples run
-the ```download_models.sh``` script in order to download a selection of models.
-These canned models will be downloaded and extracted to a new folder
-```all_models```.
+1.  First, be sure you have completed the [setup instructions for your Coral
+    device](https://coral.withgoogle.com/docs/accelerator/get-started/).
+
+    Importantly, you should have the latest TensorFlow Lite runtime installed
+    (as per the [Python quickstart](
+    https://www.tensorflow.org/lite/guide/python)
+
+2.  Clone this Git repo onto your computer:
+
+    ```
+    git clone https://github.com/google-coral/examples-camera.git
+    ```
+
+3.  Download a selection of canned models:
+
+    ```
+    cd examples-camera
+
+    ./install_requirements.sh
+    ```
+
+    These canned models will be downloaded and extracted to a new folder
+    ```all_models```.
 
 
 Further requirements may be needed by the different camera libraries, check the

--- a/gstreamer/README.md
+++ b/gstreamer/README.md
@@ -16,7 +16,8 @@ USB/PCIe/M.2 Accelerator.
 
     Importantly, you should have the latest TensorFlow Lite runtime installed
     (as per the [Python quickstart](
-    https://www.tensorflow.org/lite/guide/python)).
+    https://www.tensorflow.org/lite/guide/python)). You can check which version is installed
+    using the ```pip3 show tflite_runtime``` command.
 
 2.  Clone this Git repo onto your computer or Dev Board:
 

--- a/gstreamer/README.md
+++ b/gstreamer/README.md
@@ -14,6 +14,10 @@ USB/PCIe/M.2 Accelerator.
     device](https://coral.ai/docs/setup/). If it's been a while, repeat to be sure
     you have the latest software.
 
+    Importantly, you should have the latest TensorFlow Lite runtime installed
+    (as per the [Python quickstart](
+    https://www.tensorflow.org/lite/guide/python)).
+
 2.  Clone this Git repo onto your computer or Dev Board:
 
     ```

--- a/gstreamer/classify.py
+++ b/gstreamer/classify.py
@@ -24,7 +24,7 @@ import re
 import svgwrite
 import time
 
-Class = collections.namedtuple('Class', ['id', 'score'])
+Category = collections.namedtuple('Category', ['id', 'score'])
 
 def load_labels(path):
     p = re.compile(r'\s*(\d+)(.+)')
@@ -39,25 +39,18 @@ def generate_svg(size, text_lines):
       dwg.add(dwg.text(line, insert=(10, y*20), fill='white', font_size='20'))
     return dwg.tostring()
 
-def output_tensor(interpreter):
-    """Returns dequantized output tensor."""
-    output_details = interpreter.get_output_details()[0]
-    output_data = np.squeeze(interpreter.tensor(output_details['index'])())
-    scale, zero_point = output_details['quantization']
-    return scale * (output_data - zero_point)
-
 def get_output(interpreter, top_k, score_threshold):
-    """Returns no more than top_k classes with score >= score_threshold."""
-    scores = output_tensor(interpreter)
-    classes = [
-        Class(i, scores[i])
+    """Returns no more than top_k categories with score >= score_threshold."""
+    scores = common.output_tensor(interpreter, 0)
+    categories = [
+        Category(i, scores[i])
         for i in np.argpartition(scores, -top_k)[-top_k:]
         if scores[i] >= score_threshold
     ]
-    return sorted(classes, key=operator.itemgetter(1), reverse=True)
+    return sorted(categories, key=operator.itemgetter(1), reverse=True)
 
 def main():
-    default_model_dir = "../all_models"
+    default_model_dir = '../all_models'
     default_model = 'mobilenet_v2_1.0_224_quant_edgetpu.tflite'
     default_labels = 'imagenet_labels.txt'
     parser = argparse.ArgumentParser()
@@ -66,17 +59,17 @@ def main():
     parser.add_argument('--labels', help='label file path',
                         default=os.path.join(default_model_dir, default_labels))
     parser.add_argument('--top_k', type=int, default=3,
-                        help='number of classes with highest score to display')
+                        help='number of categories with highest score to display')
     parser.add_argument('--threshold', type=float, default=0.1,
-                        help='class score threshold')
+                        help='classifier score threshold')
     args = parser.parse_args()
 
-    print("Loading %s with %s labels."%(args.model, args.labels))
+    print('Loading {} with {} labels.'.format(args.model, args.labels))
     interpreter = common.make_interpreter(args.model)
     interpreter.allocate_tensors()
     labels = load_labels(args.labels)
 
-    w, h, _  = common.input_size(interpreter)
+    w, h, _  = common.input_image_size(interpreter)
     inference_size = (w, h)
     # Average fps over last 30 frames.
     fps_counter = common.avg_fps_counter(30)
@@ -84,17 +77,18 @@ def main():
     def user_callback(input_tensor, src_size, inference_box):
       nonlocal fps_counter
       start_time = time.monotonic()
-      common.set_interpreter(interpreter, input_tensor)
-      # For larger input tensor sizes, use the edgetpu.classification.engine for better performance
+      common.set_input(interpreter, input_tensor)
+      interpreter.invoke()
+      # For larger input image sizes, use the edgetpu.classification.engine for better performance
       results = get_output(interpreter, args.top_k, args.threshold)
       end_time = time.monotonic()
       text_lines = [
           ' ',
-          'Inference: %.2f ms' %((end_time - start_time) * 1000),
-          'FPS: %d fps' % (round(next(fps_counter))),
+          'Inference: {:.2f} ms'.format((end_time - start_time) * 1000),
+          'FPS: {} fps'.format(round(next(fps_counter))),
       ]
       for result in results:
-          text_lines.append('score=%.2f: %s' % (result.score, labels.get(result.id, result.id)))
+          text_lines.append('score={:.2f}: {}'.format(result.score, labels.get(result.id, result.id)))
       print(' '.join(text_lines))
       return generate_svg(src_size, text_lines)
 

--- a/gstreamer/classify.py
+++ b/gstreamer/classify.py
@@ -85,6 +85,7 @@ def main():
       nonlocal fps_counter
       start_time = time.monotonic()
       common.set_interpreter(interpreter, input_tensor)
+      # For larger input tensor sizes, use the edgetpu.classification.engine for better performance
       results = get_output(interpreter, args.top_k, args.threshold)
       end_time = time.monotonic()
       text_lines = [

--- a/gstreamer/detect.py
+++ b/gstreamer/detect.py
@@ -131,6 +131,7 @@ def main():
       nonlocal fps_counter
       start_time = time.monotonic()
       common.set_interpreter(interpreter, input_tensor)
+      # For larger input tensor sizes, use the edgetpu.detection.engine for better performance
       objs = get_output(interpreter, args.threshold, args.top_k)
       end_time = time.monotonic()
       text_lines = [

--- a/gstreamer/detect.py
+++ b/gstreamer/detect.py
@@ -67,16 +67,11 @@ def generate_svg(src_size, inference_size, inference_box, objs, labels, text_lin
         # Scale to source coordinate space.
         x, y, w, h = x * scale_x, y * scale_y, w * scale_x, h * scale_y
         percent = int(100 * obj.score)
-        label = '%d%% %s' % (percent, labels.get(obj.id, obj.id))
+        label = '{}% {}'.format(percent, labels.get(obj.id, obj.id))
         shadow_text(dwg, x, y - 5, label)
         dwg.add(dwg.rect(insert=(x,y), size=(w, h),
                         fill='none', stroke='red', stroke_width='2'))
     return dwg.tostring()
-
-def output_tensor(interpreter, i):
-    """Returns output tensor view."""
-    tensor = interpreter.tensor(interpreter.get_output_details()[i]['index'])()
-    return np.squeeze(tensor)
 
 class BBox(collections.namedtuple('BBox', ['xmin', 'ymin', 'xmax', 'ymax'])):
     """Bounding box.
@@ -87,14 +82,14 @@ class BBox(collections.namedtuple('BBox', ['xmin', 'ymin', 'xmax', 'ymax'])):
 
 def get_output(interpreter, score_threshold, top_k, image_scale=1.0):
     """Returns list of detected objects."""
-    boxes = output_tensor(interpreter, 0)
-    class_ids = output_tensor(interpreter, 1)
-    scores = output_tensor(interpreter, 2)
+    boxes = common.output_tensor(interpreter, 0)
+    category_ids = common.output_tensor(interpreter, 1)
+    scores = common.output_tensor(interpreter, 2)
 
     def make(i):
         ymin, xmin, ymax, xmax = boxes[i]
         return Object(
-            id=int(class_ids[i]),
+            id=int(category_ids[i]),
             score=scores[i],
             bbox=BBox(xmin=np.maximum(0.0, xmin),
                       ymin=np.maximum(0.0, ymin),
@@ -112,17 +107,17 @@ def main():
     parser.add_argument('--labels', help='label file path',
                         default=os.path.join(default_model_dir, default_labels))
     parser.add_argument('--top_k', type=int, default=3,
-                        help='number of classes with highest score to display')
+                        help='number of categories with highest score to display')
     parser.add_argument('--threshold', type=float, default=0.1,
-                        help='class score threshold')
+                        help='classifier score threshold')
     args = parser.parse_args()
 
-    print("Loading %s with %s labels."%(args.model, args.labels))
+    print('Loading {} with {} labels.'.format(args.model, args.labels))
     interpreter = common.make_interpreter(args.model)
     interpreter.allocate_tensors()
     labels = load_labels(args.labels)
 
-    w, h, _ = common.input_size(interpreter)
+    w, h, _ = common.input_image_size(interpreter)
     inference_size = (w, h)
     # Average fps over last 30 frames.
     fps_counter  = common.avg_fps_counter(30)
@@ -130,13 +125,14 @@ def main():
     def user_callback(input_tensor, src_size, inference_box):
       nonlocal fps_counter
       start_time = time.monotonic()
-      common.set_interpreter(interpreter, input_tensor)
-      # For larger input tensor sizes, use the edgetpu.detection.engine for better performance
+      common.set_input(interpreter, input_tensor)
+      interpreter.invoke()
+      # For larger input image sizes, use the edgetpu.classification.engine for better performance
       objs = get_output(interpreter, args.threshold, args.top_k)
       end_time = time.monotonic()
       text_lines = [
-          'Inference: %.2f ms' %((end_time - start_time) * 1000),
-          'FPS: %d fps' % (round(next(fps_counter))),
+          'Inference: {:.2f} ms'.format((end_time - start_time) * 1000),
+          'FPS: {} fps'.format(round(next(fps_counter))),
       ]
       print(' '.join(text_lines))
       return generate_svg(src_size, inference_size, inference_box, objs, labels, text_lines)

--- a/opencv/README.md
+++ b/opencv/README.md
@@ -11,7 +11,12 @@ USB/PCIe/M.2 Accelerator.
 ## Set up your device
 
 1.  First, be sure you have completed the [setup instructions for your Coral
-    device](https://coral.ai/docs/setup/).
+    device](https://coral.ai/docs/setup/). If it's been a while, repeat to be sure
+    you have the latest software.
+
+    Importantly, you should have the latest TensorFlow Lite runtime installed
+    (as per the [Python quickstart](
+    https://www.tensorflow.org/lite/guide/python)).
 
 2.  Clone this Git repo onto your computer or Dev Board:
 

--- a/opencv/README.md
+++ b/opencv/README.md
@@ -16,7 +16,8 @@ USB/PCIe/M.2 Accelerator.
 
     Importantly, you should have the latest TensorFlow Lite runtime installed
     (as per the [Python quickstart](
-    https://www.tensorflow.org/lite/guide/python)).
+    https://www.tensorflow.org/lite/guide/python)). You can check which version is installed
+    using the ```pip3 show tflite_runtime``` command.
 
 2.  Clone this Git repo onto your computer or Dev Board:
 

--- a/opencv/common.py
+++ b/opencv/common.py
@@ -13,14 +13,9 @@
 # limitations under the License.
 
 """Common utilities."""
-import collections
-import gi
-gi.require_version('Gst', '1.0')
-from gi.repository import Gst
 import numpy as np
-import svgwrite
+from PIL import Image
 import tflite_runtime.interpreter as tflite
-import time
 
 EDGETPU_SHARED_LIB = 'libedgetpu.so.1'
 
@@ -33,23 +28,20 @@ def make_interpreter(model_file):
                                {'device': device[0]} if device else {})
       ])
 
+def set_input(interpreter, image, resample=Image.NEAREST):
+    """Copies data to input tensor."""
+    image = image.resize((input_image_size(interpreter)[0:2]), resample)
+    input_tensor(interpreter)[:, :] = image
+
 def input_image_size(interpreter):
-    """Returns input size as (width, height, channels) tuple."""
+    """Returns input image size as (width, height, channels) tuple."""
     _, height, width, channels = interpreter.get_input_details()[0]['shape']
     return width, height, channels
 
 def input_tensor(interpreter):
-    """Returns input tensor view as numpy array of shape (height, width, channels)."""
+    """Returns input tensor view as numpy array of shape (height, width, 3)."""
     tensor_index = interpreter.get_input_details()[0]['index']
     return interpreter.tensor(tensor_index)()[0]
-
-def set_input(interpreter, buf):
-    """Copies data to input tensor."""
-    result, mapinfo = buf.map(Gst.MapFlags.READ)
-    if result:
-        np_buffer = np.reshape(np.frombuffer(mapinfo.data, dtype=np.uint8), input_image_size(interpreter))
-        input_tensor(interpreter)[:, :] = np_buffer
-        buf.unmap(mapinfo)
 
 def output_tensor(interpreter, i):
     """Returns dequantized output tensor if quantized before."""
@@ -61,14 +53,3 @@ def output_tensor(interpreter, i):
     if scale == 0:
         return output_data - zero_point
     return scale * (output_data - zero_point)
-
-def avg_fps_counter(window_size):
-    window = collections.deque(maxlen=window_size)
-    prev = time.monotonic()
-    yield 0.0  # First fps value.
-
-    while True:
-        curr = time.monotonic()
-        window.append(curr - prev)
-        prev = curr
-        yield len(window) / sum(window)

--- a/opencv/detect.py
+++ b/opencv/detect.py
@@ -26,18 +26,82 @@ python3 detect.py \
   --labels ${TEST_DATA}/coco_labels.txt
 
 """
-import cv2
-from PIL import Image
 import argparse
-import re
+import collections
+import cv2
+import numpy as np
 import os
-from edgetpu.detection.engine import DetectionEngine
+from PIL import Image
+import re
+import tflite_runtime.interpreter as tflite
+
+EDGETPU_SHARED_LIB = 'libedgetpu.so.1'
+Object = collections.namedtuple('Object', ['id', 'score', 'bbox'])
 
 def load_labels(path):
     p = re.compile(r'\s*(\d+)(.+)')
     with open(path, 'r', encoding='utf-8') as f:
        lines = (p.match(line).groups() for line in f.readlines())
        return {int(num): text.strip() for num, text in lines}
+
+def make_interpreter(model_file):
+    model_file, *device = model_file.split('@')
+    return tflite.Interpreter(
+      model_path=model_file,
+      experimental_delegates=[
+          tflite.load_delegate(EDGETPU_SHARED_LIB,
+                               {'device': device[0]} if device else {})
+      ])
+
+def input_size(interpreter):
+    """Returns input image size as (width, height) tuple."""
+    _, height, width, _ = interpreter.get_input_details()[0]['shape']
+    return width, height
+
+def input_tensor(interpreter):
+    """Returns input tensor view as numpy array of shape (height, width, 3)."""
+    tensor_index = interpreter.get_input_details()[0]['index']
+    return interpreter.tensor(tensor_index)()[0]
+
+def output_tensor(interpreter, i):
+    """Returns output tensor view."""
+    tensor = interpreter.tensor(interpreter.get_output_details()[i]['index'])()
+    return np.squeeze(tensor)
+
+def set_input(interpreter, data):
+    """Copies data to input tensor."""
+    input_tensor(interpreter)[:, :] = data
+
+def set_interpreter(interpreter, image, resample=Image.NEAREST):
+    image = image.resize((input_size(interpreter)), resample)
+    set_input(interpreter, image)
+    interpreter.invoke()
+
+class BBox(collections.namedtuple('BBox', ['xmin', 'ymin', 'xmax', 'ymax'])):
+    """Bounding box.
+    Represents a rectangle which sides are either vertical or horizontal, parallel
+    to the x or y axis.
+    """
+    __slots__ = ()
+
+def get_output(interpreter, score_threshold, top_k, image_scale=1.0):
+    """Returns list of detected objects."""
+    boxes = output_tensor(interpreter, 0)
+    class_ids = output_tensor(interpreter, 1)
+    scores = output_tensor(interpreter, 2)
+    count = int(output_tensor(interpreter, 3))
+
+    def make(i):
+        ymin, xmin, ymax, xmax = boxes[i]
+        return Object(
+            id=int(class_ids[i]),
+            score=scores[i],
+            bbox=BBox(xmin=np.maximum(0.0, xmin),
+                      ymin=np.maximum(0.0, ymin),
+                      xmax=np.minimum(1.0, xmax),
+                      ymax=np.minimum(1.0, ymax)))
+
+    return [make(i) for i in range(top_k) if scores[i] >= score_threshold]
 
 def main():
     default_model_dir = '../all_models'
@@ -55,9 +119,9 @@ def main():
     args = parser.parse_args()
 
     print("Loading %s with %s labels."%(args.model, args.labels))
-    engine = DetectionEngine(args.model)
+    interpreter = make_interpreter(args.model)
+    interpreter.allocate_tensors()
     labels = load_labels(args.labels)
-
 
     cap = cv2.VideoCapture(0)
 
@@ -69,10 +133,8 @@ def main():
 
         pil_im = Image.fromarray(cv2_im)
 
-        objs = engine.DetectWithImage(pil_im, threshold=args.threshold,
-                                    keep_aspect_ratio=True, relative_coord=True,
-                                    top_k=args.top_k)
-
+        set_interpreter(interpreter, pil_im)
+        objs = get_output(interpreter, score_threshold=args.threshold, top_k=args.top_k)
         cv2_im = append_objs_to_img(cv2_im, objs, labels)
 
         cv2.imshow('frame', cv2_im)
@@ -86,10 +148,10 @@ def main():
 def append_objs_to_img(cv2_im, objs, labels):
     height, width, channels = cv2_im.shape
     for obj in objs:
-        x0, y0, x1, y1 = obj.bounding_box.flatten().tolist()
+        x0, y0, x1, y1 = list(obj.bbox)
         x0, y0, x1, y1 = int(x0*width), int(y0*height), int(x1*width), int(y1*height)
         percent = int(100 * obj.score)
-        label = '%d%% %s' % (percent, labels[obj.label_id])
+        label = '%d%% %s' % (percent, labels.get(obj.id, obj.id))
 
         cv2_im = cv2.rectangle(cv2_im, (x0, y0), (x1, y1), (0, 255, 0), 2)
         cv2_im = cv2.putText(cv2_im, label, (x0, y0+30),

--- a/opencv/detect.py
+++ b/opencv/detect.py
@@ -28,6 +28,7 @@ python3 detect.py \
 """
 import argparse
 import collections
+import common
 import cv2
 import numpy as np
 import os
@@ -35,7 +36,6 @@ from PIL import Image
 import re
 import tflite_runtime.interpreter as tflite
 
-EDGETPU_SHARED_LIB = 'libedgetpu.so.1'
 Object = collections.namedtuple('Object', ['id', 'score', 'bbox'])
 
 def load_labels(path):
@@ -43,39 +43,6 @@ def load_labels(path):
     with open(path, 'r', encoding='utf-8') as f:
        lines = (p.match(line).groups() for line in f.readlines())
        return {int(num): text.strip() for num, text in lines}
-
-def make_interpreter(model_file):
-    model_file, *device = model_file.split('@')
-    return tflite.Interpreter(
-      model_path=model_file,
-      experimental_delegates=[
-          tflite.load_delegate(EDGETPU_SHARED_LIB,
-                               {'device': device[0]} if device else {})
-      ])
-
-def input_size(interpreter):
-    """Returns input image size as (width, height) tuple."""
-    _, height, width, _ = interpreter.get_input_details()[0]['shape']
-    return width, height
-
-def input_tensor(interpreter):
-    """Returns input tensor view as numpy array of shape (height, width, 3)."""
-    tensor_index = interpreter.get_input_details()[0]['index']
-    return interpreter.tensor(tensor_index)()[0]
-
-def output_tensor(interpreter, i):
-    """Returns output tensor view."""
-    tensor = interpreter.tensor(interpreter.get_output_details()[i]['index'])()
-    return np.squeeze(tensor)
-
-def set_input(interpreter, data):
-    """Copies data to input tensor."""
-    input_tensor(interpreter)[:, :] = data
-
-def set_interpreter(interpreter, image, resample=Image.NEAREST):
-    image = image.resize((input_size(interpreter)), resample)
-    set_input(interpreter, image)
-    interpreter.invoke()
 
 class BBox(collections.namedtuple('BBox', ['xmin', 'ymin', 'xmax', 'ymax'])):
     """Bounding box.
@@ -86,10 +53,10 @@ class BBox(collections.namedtuple('BBox', ['xmin', 'ymin', 'xmax', 'ymax'])):
 
 def get_output(interpreter, score_threshold, top_k, image_scale=1.0):
     """Returns list of detected objects."""
-    boxes = output_tensor(interpreter, 0)
-    class_ids = output_tensor(interpreter, 1)
-    scores = output_tensor(interpreter, 2)
-    count = int(output_tensor(interpreter, 3))
+    boxes = common.output_tensor(interpreter, 0)
+    class_ids = common.output_tensor(interpreter, 1)
+    scores = common.output_tensor(interpreter, 2)
+    count = int(common.output_tensor(interpreter, 3))
 
     def make(i):
         ymin, xmin, ymax, xmax = boxes[i]
@@ -113,13 +80,13 @@ def main():
     parser.add_argument('--labels', help='label file path',
                         default=os.path.join(default_model_dir, default_labels))
     parser.add_argument('--top_k', type=int, default=3,
-                        help='number of classes with highest score to display')
+                        help='number of categories with highest score to display')
     parser.add_argument('--threshold', type=float, default=0.1,
-                        help='class score threshold')
+                        help='classifier score threshold')
     args = parser.parse_args()
 
-    print("Loading %s with %s labels."%(args.model, args.labels))
-    interpreter = make_interpreter(args.model)
+    print('Loading {} with {} labels.'.format(args.model, args.labels))
+    interpreter = common.make_interpreter(args.model)
     interpreter.allocate_tensors()
     labels = load_labels(args.labels)
 
@@ -133,7 +100,8 @@ def main():
 
         pil_im = Image.fromarray(cv2_im)
 
-        set_interpreter(interpreter, pil_im)
+        common.set_input(interpreter, pil_im)
+        interpreter.invoke()
         objs = get_output(interpreter, score_threshold=args.threshold, top_k=args.top_k)
         cv2_im = append_objs_to_img(cv2_im, objs, labels)
 
@@ -144,20 +112,18 @@ def main():
     cap.release()
     cv2.destroyAllWindows()
 
-
 def append_objs_to_img(cv2_im, objs, labels):
     height, width, channels = cv2_im.shape
     for obj in objs:
         x0, y0, x1, y1 = list(obj.bbox)
         x0, y0, x1, y1 = int(x0*width), int(y0*height), int(x1*width), int(y1*height)
         percent = int(100 * obj.score)
-        label = '%d%% %s' % (percent, labels.get(obj.id, obj.id))
+        label = '{}% {}'.format(percent, labels.get(obj.id, obj.id))
 
         cv2_im = cv2.rectangle(cv2_im, (x0, y0), (x1, y1), (0, 255, 0), 2)
         cv2_im = cv2.putText(cv2_im, label, (x0, y0+30),
                              cv2.FONT_HERSHEY_SIMPLEX, 1.0, (255, 0, 0), 2)
     return cv2_im
-
 
 if __name__ == '__main__':
     main()

--- a/opencv/install_requirements.sh
+++ b/opencv/install_requirements.sh
@@ -26,3 +26,5 @@ fi
 sudo pip3 install opencv-contrib-python
 sudo apt-get -y install libjasper1 libhdf5-100 libqtgui4 libatlas-base-dev libqt4-test
 sudo apt install python3-opencv
+# For Rasperry Pi: this command works for Raspbian Buster and onwwards. For older versions
+# you can build OpenCV yourself or install the unofficial opencv-contrib-python package.

--- a/opencv/install_requirements.sh
+++ b/opencv/install_requirements.sh
@@ -23,4 +23,6 @@ if grep -s -q "MX8MQ" /sys/firmware/devicetree/base/model; then
   fi
 fi
 
+sudo pip3 install opencv-contrib-python
+sudo apt-get -y install libjasper1 libhdf5-100 libqtgui4 libatlas-base-dev libqt4-test
 sudo apt install python3-opencv

--- a/pygame/README.md
+++ b/pygame/README.md
@@ -34,7 +34,6 @@ camera images and then perform image classification or object detection on the E
 
 
 ## Run the classification demo
-
 ```
 python3 classify_capture.py
 ```
@@ -53,5 +52,3 @@ python3 detect.py
 By default, this uses the ```mobilenet_ssd_v2_coco_quant_postprocess_edgetpu.tflite``` model.
 
 You can change the model and the labels file using flags ```--model``` and ```--labels```.
-
-

--- a/pygame/README.md
+++ b/pygame/README.md
@@ -3,6 +3,8 @@
 This folder contains example code using [pygame](https://github.com/pygame/pygame) to obtain
 camera images and then perform image classification or object detection on the Edge TPU.
 
+This code works on Linux using a webcam, Raspberry Pi with the Pi Camera, and on the Coral Dev Board using a webcam. For the first two, you also need a Coral USB/PCIe/M.2 Accelerator.
+
 ## Set up your device
 
 1.  First, be sure you have completed the [setup instructions for your Coral

--- a/pygame/README.md
+++ b/pygame/README.md
@@ -8,7 +8,12 @@ This code works on Linux using a webcam, Raspberry Pi with the Pi Camera, and on
 ## Set up your device
 
 1.  First, be sure you have completed the [setup instructions for your Coral
-    device](https://coral.ai/docs/setup/).
+    device](https://coral.ai/docs/setup/). If it's been a while, repeat to be sure
+    you have the latest software.
+
+    Importantly, you should have the latest TensorFlow Lite runtime installed
+    (as per the [Python quickstart](
+    https://www.tensorflow.org/lite/guide/python)).
 
 2.  Clone this Git repo onto your computer or Dev Board:
 

--- a/pygame/README.md
+++ b/pygame/README.md
@@ -13,7 +13,8 @@ This code works on Linux using a webcam, Raspberry Pi with the Pi Camera, and on
 
     Importantly, you should have the latest TensorFlow Lite runtime installed
     (as per the [Python quickstart](
-    https://www.tensorflow.org/lite/guide/python)).
+    https://www.tensorflow.org/lite/guide/python)). You can check which version is installed
+    using the ```pip3 show tflite_runtime``` command.
 
 2.  Clone this Git repo onto your computer or Dev Board:
 

--- a/pygame/classify_capture.py
+++ b/pygame/classify_capture.py
@@ -14,16 +14,61 @@
 
 """A demo to classify Pygame camera stream."""
 import argparse
-import os
-import io
-import time
+import collections
 from collections import deque
+import io
 import numpy as np
+import operator
+import os
 import pygame
 import pygame.camera
 from pygame.locals import *
+import tflite_runtime.interpreter as tflite
+import time
 
-import edgetpu.classification.engine
+Class = collections.namedtuple('Class', ['id', 'score'])
+EDGETPU_SHARED_LIB = 'libedgetpu.so.1'
+
+def make_interpreter(model_file):
+    model_file, *device = model_file.split('@')
+    return tflite.Interpreter(
+      model_path=model_file,
+      experimental_delegates=[
+          tflite.load_delegate(EDGETPU_SHARED_LIB,
+                               {'device': device[0]} if device else {})
+      ])
+
+def input_size(interpreter):
+    """Returns input image size as (width, height, channels) tuple."""
+    _, height, width, channels = interpreter.get_input_details()[0]['shape']
+    return width, height, channels
+
+def input_tensor(interpreter):
+    """Returns input tensor view as numpy array of shape (height, width, 3)."""
+    tensor_index = interpreter.get_input_details()[0]['index']
+    return interpreter.tensor(tensor_index)()[0]
+
+def output_tensor(interpreter):
+    """Returns dequantized output tensor."""
+    output_details = interpreter.get_output_details()[0]
+    output_data = np.squeeze(interpreter.tensor(output_details['index'])())
+    scale, zero_point = output_details['quantization']
+    return scale * (output_data - zero_point)
+
+def set_interpreter(interpreter, data):
+    """Copies data to input tensor."""
+    input_tensor(interpreter)[:,:] = np.reshape(data, (input_size(interpreter)))
+    interpreter.invoke()
+
+def get_output(interpreter, top_k, score_threshold):
+    """Returns no more than top_k classes with score >= score_threshold."""
+    scores = output_tensor(interpreter)
+    classes = [
+        Class(i, scores[i])
+        for i in np.argpartition(scores, -top_k)[-top_k:]
+        if scores[i] >= score_threshold
+    ]
+    return sorted(classes, key=operator.itemgetter(1), reverse=True)
 
 def main():
     default_model_dir = "../all_models"
@@ -40,7 +85,8 @@ def main():
         pairs = (l.strip().split(maxsplit=1) for l in f.readlines())
         labels = dict((int(k), v) for k, v in pairs)
 
-    engine = edgetpu.classification.engine.ClassificationEngine(args.model)
+    interpreter = make_interpreter(args.model)
+    interpreter.allocate_tensors()
 
     pygame.init()
     pygame.camera.init()
@@ -48,7 +94,7 @@ def main():
 
     print("By default using camera: ", camlist[-1])
     camera = pygame.camera.Camera(camlist[-1], (640, 480)) 
-    _, width, height, channels = engine.get_input_tensor_shape()
+    width, height, channels = input_size(interpreter)
     camera.start()
     try:
         fps = deque(maxlen=20)
@@ -58,7 +104,8 @@ def main():
             imagen = pygame.transform.scale(imagen, (width, height))
             input = np.frombuffer(imagen.get_buffer(), dtype=np.uint8)
             start_ms = time.time()
-            results = engine.classify_with_input_tensor(input, top_k=3)
+            set_interpreter(interpreter, input)
+            results = get_output(interpreter, top_k=3, score_threshold=0)
             inference_ms = (time.time() - start_ms)*1000.0
             fps.append(time.time())
             fps_ms = len(fps)/(fps[-1] - fps[0])

--- a/pygame/install_requirements.sh
+++ b/pygame/install_requirements.sh
@@ -18,6 +18,7 @@ if grep -s -q "MX8MQ" /sys/firmware/devicetree/base/model; then
   sudo apt-get install -y python3-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev   libsdl1.2-dev libsmpeg-dev python-numpy subversion libportmidi-dev ffmpeg libswscale-dev libavformat-dev libavcodec-dev libfreetype6-dev
   sudo pip3 install pygame
 else
+  sudo apt-get install -y libsdl-image1.2-dev libsdl-ttf2.0-dev libatlas-base-dev
   sudo pip3 install pygame
 fi
 

--- a/raspicam/README.md
+++ b/raspicam/README.md
@@ -14,7 +14,8 @@ This code works on Raspberry Pi with the Pi Camera and Coral USB Accelerator.
 
     Importantly, you should have the latest TensorFlow Lite runtime installed
     (as per the [Python quickstart](
-    https://www.tensorflow.org/lite/guide/python)).
+    https://www.tensorflow.org/lite/guide/python)). You can check which version is installed
+    using the ```pip3 show tflite_runtime``` command.
 
 
 2.  Follow the guide to [connect and configure the Pi Camera](

--- a/raspicam/README.md
+++ b/raspicam/README.md
@@ -9,7 +9,13 @@ This code works on Raspberry Pi with the Pi Camera and Coral USB Accelerator.
 ## Set up your device
 
 1.  First, be sure you have completed the [setup instructions for the USB
-    Accelerator](https://coral.ai/docs/accelerator/get-started/).
+    Accelerator](https://coral.ai/docs/accelerator/get-started/). If it's been a while, repeat to be sure
+    you have the latest software.
+
+    Importantly, you should have the latest TensorFlow Lite runtime installed
+    (as per the [Python quickstart](
+    https://www.tensorflow.org/lite/guide/python)).
+
 
 2.  Follow the guide to [connect and configure the Pi Camera](
     https://www.raspberrypi.org/documentation/configuration/camera.md).

--- a/raspicam/classify_capture.py
+++ b/raspicam/classify_capture.py
@@ -16,6 +16,7 @@
 import argparse
 import collections
 from collections import deque
+import common
 import io
 import numpy as np
 import operator
@@ -24,52 +25,20 @@ import picamera
 import tflite_runtime.interpreter as tflite
 import time
 
-Class = collections.namedtuple('Class', ['id', 'score'])
-EDGETPU_SHARED_LIB = 'libedgetpu.so.1'
-
-def make_interpreter(model_file):
-    model_file, *device = model_file.split('@')
-    return tflite.Interpreter(
-      model_path=model_file,
-      experimental_delegates=[
-          tflite.load_delegate(EDGETPU_SHARED_LIB,
-                               {'device': device[0]} if device else {})
-      ])
-
-def input_size(interpreter):
-    """Returns input image size as (width, height, channels) tuple."""
-    _, height, width, channels = interpreter.get_input_details()[0]['shape']
-    return width, height, channels
-
-def input_tensor(interpreter):
-    """Returns input tensor view as numpy array of shape (height, width, 3)."""
-    tensor_index = interpreter.get_input_details()[0]['index']
-    return interpreter.tensor(tensor_index)()[0]
-
-def output_tensor(interpreter):
-    """Returns dequantized output tensor."""
-    output_details = interpreter.get_output_details()[0]
-    output_data = np.squeeze(interpreter.tensor(output_details['index'])())
-    scale, zero_point = output_details['quantization']
-    return scale * (output_data - zero_point)
-
-def set_interpreter(interpreter, data):
-    """Copies data to input tensor."""
-    input_tensor(interpreter)[:,:] = np.reshape(data, input_size(interpreter))
-    interpreter.invoke()
+Category = collections.namedtuple('Category', ['id', 'score'])
 
 def get_output(interpreter, top_k, score_threshold):
-    """Returns no more than top_k classes with score >= score_threshold."""
-    scores = output_tensor(interpreter)
-    classes = [
-        Class(i, scores[i])
+    """Returns no more than top_k categories with score >= score_threshold."""
+    scores = common.output_tensor(interpreter, 0)
+    categories = [
+        Category(i, scores[i])
         for i in np.argpartition(scores, -top_k)[-top_k:]
         if scores[i] >= score_threshold
     ]
-    return sorted(classes, key=operator.itemgetter(1), reverse=True)
+    return sorted(categories, key=operator.itemgetter(1), reverse=True)
 
 def main():
-    default_model_dir = "../all_models"
+    default_model_dir = '../all_models'
     default_model = 'mobilenet_v2_1.0_224_quant_edgetpu.tflite'
     default_labels = 'imagenet_labels.txt'
     parser = argparse.ArgumentParser()
@@ -83,14 +52,14 @@ def main():
         pairs = (l.strip().split(maxsplit=1) for l in f.readlines())
         labels = dict((int(k), v) for k, v in pairs)
 
-    interpreter = make_interpreter(args.model)
+    interpreter = common.make_interpreter(args.model)
     interpreter.allocate_tensors()
 
     with picamera.PiCamera() as camera:
         camera.resolution = (640, 480)
         camera.framerate = 30
         camera.annotate_text_size = 20
-        width, height, channels = input_size(interpreter)
+        width, height, channels = common.input_image_size(interpreter)
         camera.start_preview()
         try:
             stream = io.BytesIO()
@@ -104,14 +73,15 @@ def main():
                 stream.seek(0)
                 input = np.frombuffer(stream.getvalue(), dtype=np.uint8)
                 start_ms = time.time()
-                set_interpreter(interpreter, input)
+                common.input_tensor(interpreter)[:,:] = np.reshape(input, common.input_image_size(interpreter))
+                interpreter.invoke()
                 results = get_output(interpreter, top_k=3, score_threshold=0)
                 inference_ms = (time.time() - start_ms)*1000.0
                 fps.append(time.time())
                 fps_ms = len(fps)/(fps[-1] - fps[0])
-                camera.annotate_text = "Inference: %5.2fms FPS: %3.1f" % (inference_ms, fps_ms)
+                camera.annotate_text = 'Inference: {:5.2f}ms FPS: {:3.1f}'.format(inference_ms, fps_ms)
                 for result in results:
-                   camera.annotate_text += "\n%.0f%% %s" % (100*result[1], labels[result[0]])
+                   camera.annotate_text += '\n{:.0f}% {}'.format(100*result[1], labels[result[0]])
                 print(camera.annotate_text)
         finally:
             camera.stop_preview()

--- a/raspicam/classify_capture.py
+++ b/raspicam/classify_capture.py
@@ -14,14 +14,59 @@
 
 """A demo to classify Raspberry Pi camera stream."""
 import argparse
-import os
-import io
-import time
+import collections
 from collections import deque
+import io
 import numpy as np
+import operator
+import os
 import picamera
+import tflite_runtime.interpreter as tflite
+import time
 
-import edgetpu.classification.engine
+Class = collections.namedtuple('Class', ['id', 'score'])
+EDGETPU_SHARED_LIB = 'libedgetpu.so.1'
+
+def make_interpreter(model_file):
+    model_file, *device = model_file.split('@')
+    return tflite.Interpreter(
+      model_path=model_file,
+      experimental_delegates=[
+          tflite.load_delegate(EDGETPU_SHARED_LIB,
+                               {'device': device[0]} if device else {})
+      ])
+
+def input_size(interpreter):
+    """Returns input image size as (width, height, channels) tuple."""
+    _, height, width, channels = interpreter.get_input_details()[0]['shape']
+    return width, height, channels
+
+def input_tensor(interpreter):
+    """Returns input tensor view as numpy array of shape (height, width, 3)."""
+    tensor_index = interpreter.get_input_details()[0]['index']
+    return interpreter.tensor(tensor_index)()[0]
+
+def output_tensor(interpreter):
+    """Returns dequantized output tensor."""
+    output_details = interpreter.get_output_details()[0]
+    output_data = np.squeeze(interpreter.tensor(output_details['index'])())
+    scale, zero_point = output_details['quantization']
+    return scale * (output_data - zero_point)
+
+def set_interpreter(interpreter, data):
+    """Copies data to input tensor."""
+    input_tensor(interpreter)[:,:] = np.reshape(data, input_size(interpreter))
+    interpreter.invoke()
+
+def get_output(interpreter, top_k, score_threshold):
+    """Returns no more than top_k classes with score >= score_threshold."""
+    scores = output_tensor(interpreter)
+    classes = [
+        Class(i, scores[i])
+        for i in np.argpartition(scores, -top_k)[-top_k:]
+        if scores[i] >= score_threshold
+    ]
+    return sorted(classes, key=operator.itemgetter(1), reverse=True)
 
 def main():
     default_model_dir = "../all_models"
@@ -38,13 +83,14 @@ def main():
         pairs = (l.strip().split(maxsplit=1) for l in f.readlines())
         labels = dict((int(k), v) for k, v in pairs)
 
-    engine = edgetpu.classification.engine.ClassificationEngine(args.model)
+    interpreter = make_interpreter(args.model)
+    interpreter.allocate_tensors()
 
     with picamera.PiCamera() as camera:
         camera.resolution = (640, 480)
         camera.framerate = 30
         camera.annotate_text_size = 20
-        _, width, height, channels = engine.get_input_tensor_shape()
+        width, height, channels = input_size(interpreter)
         camera.start_preview()
         try:
             stream = io.BytesIO()
@@ -58,7 +104,8 @@ def main():
                 stream.seek(0)
                 input = np.frombuffer(stream.getvalue(), dtype=np.uint8)
                 start_ms = time.time()
-                results = engine.ClassifyWithInputTensor(input, top_k=3)
+                set_interpreter(interpreter, input)
+                results = get_output(interpreter, top_k=3, score_threshold=0)
                 inference_ms = (time.time() - start_ms)*1000.0
                 fps.append(time.time())
                 fps_ms = len(fps)/(fps[-1] - fps[0])


### PR DESCRIPTION
This PR converts all examples for Gstreamer, OpenCV, PyGame, and Raspicam. The README files and install_requirements.sh scripts were also updated as needed.

The make_interpreter, input_size, input_tensor, output_tensor, set_input, get_output functions are all based on [this TFLite classification example](https://github.com/google-coral/tflite/blob/master/python/examples/classification/classify_image.py) whose functions are defined [here](https://github.com/google-coral/tflite/blob/master/python/examples/classification/classify.py)

Tested: Camera examples run for the Coral Dev Board, Raspberry Pi with USB Accelerator, and Linux with USB Accelerator. 

In open_cv/install_requirements.sh for Raspberry Pi when if it just calls ```sudo pip3 install opencv-contrib-python``` an error states that it’s unable to locate package python3-opencv. This works for the Coral Board (and Linux). The only instructions I found for installing OpenCV for Raspberry Pi are a [very involved process](https://www.deciphertechnic.com/install-opencv-python-on-raspberry-pi/) (I could still try to include this in the script), but the other fix I found uses opencv-contrib-python and installs some additional libraries which I added to the install_requirements.sh script