### PR TITLE
Fix inference on non square inputs

### DIFF
--- a/gstreamer/common.py
+++ b/gstreamer/common.py
@@ -47,7 +47,8 @@ def set_input(interpreter, buf):
     """Copies data to input tensor."""
     result, mapinfo = buf.map(Gst.MapFlags.READ)
     if result:
-        np_buffer = np.reshape(np.frombuffer(mapinfo.data, dtype=np.uint8), input_image_size(interpreter))
+        np_buffer = np.reshape(np.frombuffer(mapinfo.data, dtype=np.uint8),
+            interpreter.get_input_details()[0]['shape'])
         input_tensor(interpreter)[:, :] = np_buffer
         buf.unmap(mapinfo)
 


### PR DESCRIPTION
When reshaping the input tensor data height and width are swapped
in input_image_size. If they're different (non square) setting the
input tensor data will fail due to incompatible shape.