### PR TITLE
Add gstreamer1.0-libav dependency for h264 decoding

### DIFF
--- a/gstreamer/install_requirements.sh
+++ b/gstreamer/install_requirements.sh
@@ -16,8 +16,8 @@
 if grep -s -q "Mendel" /etc/os-release; then
   echo "No DevBoard specific dependencies"
 else
-  # Install gstreamer 
-  sudo apt-get install -y gstreamer1.0-plugins-bad gstreamer1.0-plugins-good python3-gst-1.0 python3-gi gir1.2-gtk-3.0
+  # Install gstreamer
+  sudo apt-get install -y gstreamer1.0-libav gstreamer1.0-plugins-bad gstreamer1.0-plugins-good python3-gst-1.0 python3-gi gir1.2-gtk-3.0
 
   if grep -s -q "Raspberry Pi" /sys/firmware/devicetree/base/model; then
     echo "Installing Raspberry Pi specific dependencies"
@@ -26,6 +26,6 @@ else
     if ! grep -q "bcm2835-v4l2" /etc/modules; then
       echo bcm2835-v4l2 | sudo tee -a /etc/modules
     fi
-    sudo modprobe bcm2835-v4l2 
+    sudo modprobe bcm2835-v4l2
   fi
 fi


### PR DESCRIPTION
I was unable to get the gstreamer classify example working with the USB accelerator due to the following error:

```
Error: gst-core-error-quark: Your GStreamer installation is missing a plug-in. (12): ../gst/playback/gstdecodebin2.c(4719): gst_decode_bin_expose (): /GstPipeline:pipeline0/GstDecodeBin:decodebin0:
no suitable plugins found:
Missing decoder: H.264 (Main Profile) (video/x-h264, stream-format=(string)byte-stream, alignment=(string)au, level=(string)5, profile=(string)main, width=(int)1920, height=(int)1080, framerate=(fraction)15/1, chroma-format=(string)4:2:0, bit-depth-luma=(uint)8, bit-depth-chroma=(uint)8, colorimetry=(string)bt709, parsed=(boolean)true)
```

Installing `gstreamer1.0-libav` resolved the issue